### PR TITLE
Update to api 5.13.0 and protocol 662 / fix gamePacketLimiter

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: FixServerCrash
 version: 1.0.0
-api: 5.11.0
-mcpe-protocol: 649
+api: 5.13.0
+mcpe-protocol: 662
 main: Zwuiix\FixServerCrash\FixServerCrash
 authors:
   - Zwuiix

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,4 +1,4 @@
-# This will simply remove the version of the motd in Minecraft, e.g. "Your server - 1.20.50", it will now be "Your Server".
+# This will simply remove the version of the motd in Minecraft, e.g. "Your server - 1.20.60", it will now be "Your Server".
 clean-motd: true
 
 # This removes the need to display ip addresses when a player connects to the server, so you don't have to store players' ip addresses in your server logs.

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,4 +1,4 @@
-# This will simply remove the version of the motd in Minecraft, e.g. "Your server - 1.20.60", it will now be "Your Server".
+# This will simply remove the version of the motd in Minecraft, e.g. "Your server - 1.20.70", it will now be "Your Server".
 clean-motd: true
 
 # This removes the need to display ip addresses when a player connects to the server, so you don't have to store players' ip addresses in your server logs.

--- a/src/Zwuiix/FixServerCrash/FixServerCrash.php
+++ b/src/Zwuiix/FixServerCrash/FixServerCrash.php
@@ -13,7 +13,7 @@ class FixServerCrash extends PluginBase
 {
     use SingletonTrait;
 
-    const MINIMUM_API_VERSION = "5.11.0";
+    const MINIMUM_API_VERSION = "5.13.0";
     const CLEAN_MOTD = "cleanMotd";
     const REMOVE_IPS = "removeIps";
     const DISABLE_PACKETLIMITER = "disablePacketLimiter";

--- a/src/Zwuiix/FixServerCrash/listener/ServerListener.php
+++ b/src/Zwuiix/FixServerCrash/listener/ServerListener.php
@@ -31,7 +31,6 @@ class ServerListener
             $newInterface = new CustomRakLibInterface($server, $server->getIp(), $server->getPort(), false,
                 ReflectionUtils::getProperty(RakLibInterface::class, $interface, "packetBroadcaster"),
                 ReflectionUtils::getProperty(RakLibInterface::class, $interface, "entityEventBroadcaster"),
-                ReflectionUtils::getProperty(RakLibInterface::class, $interface, "packetSerializerContext"),
                 ReflectionUtils::getProperty(RakLibInterface::class, $interface, "typeConverter"),
             );
             $server->getNetwork()->registerInterface($newInterface);

--- a/src/Zwuiix/FixServerCrash/network/CustomNetworkSession.php
+++ b/src/Zwuiix/FixServerCrash/network/CustomNetworkSession.php
@@ -189,7 +189,6 @@ class CustomNetworkSession extends NetworkSession
                 $stream = new BinaryStream($decompressed);
                 $count = 0;
                 foreach(PacketBatch::decodeRaw($stream) as $buffer){
-                    ReflectionUtils::getProperty(NetworkSession::class, $this, "gamePacketLimiter")->decrement();
                     if(++$count > 100){
                         throw new PacketHandlingException("Too many packets in batch");
                     }

--- a/src/Zwuiix/FixServerCrash/network/CustomRakLibInterface.php
+++ b/src/Zwuiix/FixServerCrash/network/CustomRakLibInterface.php
@@ -9,7 +9,6 @@ use pocketmine\network\mcpe\EntityEventBroadcaster;
 use pocketmine\network\mcpe\PacketBroadcaster;
 use pocketmine\network\mcpe\protocol\PacketPool;
 use pocketmine\network\mcpe\protocol\ProtocolInfo;
-use pocketmine\network\mcpe\protocol\serializer\PacketSerializerContext;
 use pocketmine\network\mcpe\raklib\RakLibInterface;
 use pocketmine\network\mcpe\raklib\RakLibPacketSender;
 use pocketmine\network\PacketHandlingException;
@@ -33,10 +32,9 @@ class CustomRakLibInterface extends RakLibInterface
         bool $ipV6,
         protected PacketBroadcaster $packetBroadcaster,
         protected EntityEventBroadcaster $entityEventBroadcaster,
-        protected PacketSerializerContext $packetSerializerContext,
         protected TypeConverter $typeConverter
     ) {
-        parent::__construct($server, $ip, $port, $ipV6, $packetBroadcaster, $entityEventBroadcaster, $packetSerializerContext, $typeConverter);
+        parent::__construct($server, $ip, $port, $ipV6, $packetBroadcaster, $entityEventBroadcaster, $typeConverter);
     }
 
     /**
@@ -141,7 +139,6 @@ class CustomRakLibInterface extends RakLibInterface
             $this->server,
             $network->getSessionManager(),
             PacketPool::getInstance(),
-            $this->packetSerializerContext,
             new RakLibPacketSender($sessionId, $this),
             $this->packetBroadcaster,
             $this->entityEventBroadcaster,


### PR DESCRIPTION
## Introduction
Update the incredible plugin FixServerCrash to api 5.13.0 and protocol 662 and fix gamePacketLimiter

## Changes
``ReflectionUtils::getProperty(RakLibInterface::class, $interface, "packetSerializerContext")`` in ``ServerListener.php`` has been removed

``protected PacketSerializerContext $packetSerializerContext`` in ``CustomRaklibInterface.php`` has been removed

``$packetSerializerContext`` in the construct of ``CustomRaklibInterface.php`` has been removed

``$this->packetSerializerContext`` in ``CustomRaklibInterface->onClientConnect`` has been removed

``ReflectionUtils::getProperty(NetworkSession::class, $this, "gamePacketLimiter")->decrement()`` in ``CustomNetworkSession.php`` has been removed